### PR TITLE
Fix: Move JavaScript to end of template to prevent page refresh on st…

### DIFF
--- a/templates/project_detail.html
+++ b/templates/project_detail.html
@@ -262,8 +262,6 @@
     </div>
 </div>
 
-<script src="{{ url_for('static', filename='js/project_detail.js') }}"></script>
-
 <div class="row mt-4">
     <div class="col-12">
         <h3>Pattern Parts</h3>
@@ -406,4 +404,6 @@
         {% endfor %}
     </div>
 </div>
+
+<script src="{{ url_for('static', filename='js/project_detail.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
…ep toggle

Issue: Step checkboxes were causing page refreshes instead of AJAX toggles

Root Cause:
- JavaScript file was loading at line 265 (middle of template)
- Step checkboxes were rendered at line 345+ (later in template)
- Event listeners couldn't attach to elements that didn't exist yet
- Result: Checkboxes had no click handler, so default behavior occurred

Fix:
- Moved <script> tag from line 265 to line 408 (end of template)
- JavaScript now loads AFTER all HTML elements are rendered
- Event listeners can properly attach to step checkboxes
- AJAX toggle now works without page refresh

Verified:
✓ Checkboxes render before JavaScript loads
✓ Event listeners attach successfully
✓ AJAX toggle returns JSON correctly
✓ No page refresh on checkbox click
✓ Scroll position preserved

This fixes the reported issue where checking/unchecking steps still caused page refreshes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)